### PR TITLE
Correct link to copyright in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In accordance with Sublime Text's EULA, all files except for `.foundryrc`, `.git
 
 Here are the specific lines regarding that ownership:
 
-[Copyright lines](EULA#L53-L54)
+[Copyright lines](EULA#L106-L107)
 
 With respect to the excepted files (`.foundryrc`, `.gitignore`, `CHANGELOG.md`, `README.md`, `UNLICENSE`, `delete-sublime.sh`, `download-eula.sh`, `extract-sublime.sh`, `release.sh`), those are released to the Public Domain by Todd Wolfson under the [UNLICENSE][].
 


### PR DESCRIPTION
The README is out of date with the EULA. In particular, it links to lines 53–54 as those giving Sublime HQ Pty Ltd. copyright, whereas that information actually appears in lines 106–107. This change brings the link in the README up-to-date with the EULA.